### PR TITLE
Add skeleton screen for when posters are loading

### DIFF
--- a/src/components/AllMovies/AllMovies.js
+++ b/src/components/AllMovies/AllMovies.js
@@ -32,6 +32,10 @@ class AllMovies extends React.Component {
       : this.setState({ movies : this.renderPosters(searchResults), error: ''})
   }
 
+  skeletonScreen = () => {
+    return new Array(40).fill('placeholder').map((item, index) => <div key={index} className="movie-loading"><br /><br /></div>)
+  }
+
   renderPosters = (movies) => {
     return movies.map(movie => {
       return (
@@ -50,8 +54,12 @@ class AllMovies extends React.Component {
     return (
       <div className="all-container">
         {!this.state.movies.length && this.state.error && <ErrorComponent type="500" />}
-        {!this.state.rawData.length && <h2 className="loading">Loading...</h2>}
-        {this.state.rawData.length ? <Search data={this.state.rawData} updateMovies={this.updateMoviesState} /> : null}
+        <Search data={this.state.rawData} updateMovies={this.updateMoviesState} />
+        {!this.state.rawData.length &&
+          <div className='all-movies-container'>
+            {this.skeletonScreen()}
+          </div>
+        }
         {this.state.error && <h2>{this.state.error}</h2>}
         {!this.state.error &&
           <div className='all-movies-container'>

--- a/src/components/Movie/Movie.css
+++ b/src/components/Movie/Movie.css
@@ -5,6 +5,12 @@
     cursor: pointer;
 }
 
+.movie-loading {
+  width: 236px;
+  height: 354px;
+  background-color: gray;
+}
+
 .movie:hover {
   transform: scale3d(1.1, 1.1, 1.1);
   box-shadow: 5px 5px 15px 5px rgba(0,0,0,0.2);


### PR DESCRIPTION
# Description
Add skeleton screen for posters so that when movies are loading, there are gray boxes that suggest to the user that they are placeholders for content 

## Issues Closed

## Type of change
Check the relevant option:

- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Navigate site per usual 